### PR TITLE
Add/fix Dreamwidth support

### DIFF
--- a/ljmigrate.cfg.sample
+++ b/ljmigrate.cfg.sample
@@ -22,8 +22,10 @@ migrate-community-posts-by-others: False
 server: www.livejournal.com
 # Your user name.
 user: myusername
-# Your password. Will not be sent in the clear; this tool uses the challenge
-# response authentication mechanism.
+# Your password. This will be send as part of a challenge-response
+# authentication (so not as cleartext), except with dreamwidth
+# where it will be send as cleartext over HTTPS relying on the
+* HTTPS encryption to protect it.
 password: mypassword
 # communities: sourcecomm1 sourcecomm2
 

--- a/ljmigrate.cfg.sample
+++ b/ljmigrate.cfg.sample
@@ -37,7 +37,7 @@ password: myotherpassword
 
 # [nuke]
 # option section for the nuclear option; see README for details
-# server: http://insanejournal.com
+# server: https://insanejournal.com
 # user: myotheruser
 # password: myotherpassword
 # community: comm_to_nuke (optional)

--- a/ljmigrate.py
+++ b/ljmigrate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 Based on ljdump; original ljdump license & header in LICENCE.text.

--- a/ljmigrate.py
+++ b/ljmigrate.py
@@ -71,7 +71,7 @@ class ProxiedTransport(xmlrpclib.Transport):
 
 	# overridden
 	def send_request(self, connection, handler, request_body):
-		connection.putrequest("POST", 'http://%s%s' % (self.realhost, handler))
+		connection.putrequest("POST", 'https://%s%s' % (self.realhost, handler))
 
 	# overridden
 	def send_host(self, connection, host):
@@ -91,12 +91,12 @@ class Account(object):
 		else:
 			self.host = host
 
-		m = re.search("http://(.*)", host)
+		m = re.search("https://(.*)", host)
 		if m:
 			self.site = m.group(1)
 		else:
 			self.site = host
-			self.host = "http://" + host
+			self.host = "https://" + host
 
 		self.user = user
 		self.password = password
@@ -793,8 +793,8 @@ class Entry(object):
 
 		if hasattr(self, 'subject'):
 			subject = self.getStringAttribute('subject')
-			subject = userpattern.sub(r'<b><a href="http://\1.%s/"><img src="http://stat.livejournal.com/img/userinfo.gif" alt="[info]" width="17" height="17" style="vertical-align: bottom; border: 0;" />\1</a></b>' % gSourceAccount.site, subject)
-			subject = commpattern.sub(r'<b><a href="http://community.%s/\1/"><img src="http://stat.livejournal.com/img/community.gif" alt="[info]" width="16" height="16" style="vertical-align: bottom; border: 0;" />\1</a></b>' % gSourceAccount.site, subject)
+			subject = userpattern.sub(r'<b><a href="https://\1.%s/"><img src="https://stat.livejournal.com/img/userinfo.gif" alt="[info]" width="17" height="17" style="vertical-align: bottom; border: 0;" />\1</a></b>' % gSourceAccount.site, subject)
+			subject = commpattern.sub(r'<b><a href="https://community.%s/\1/"><img src="https://stat.livejournal.com/img/community.gif" alt="[info]" width="16" height="16" style="vertical-align: bottom; border: 0;" />\1</a></b>' % gSourceAccount.site, subject)
 		else:
 			subject = "(No Subject)"
 
@@ -842,8 +842,8 @@ class Entry(object):
 			content = self.getStringAttribute('event')
 			if not properties.has_key('opt_preformatted'):
 				content = content.replace("\n", "<br />\n");
-			content = userpattern.sub(r'<b><a href="http://\1.%s/"><img src="http://stat.livejournal.com/img/userinfo.gif" alt="[info]" width="17" height="17" style="vertical-align: bottom; border: 0;" />\1</a></b>' % gSourceAccount.site, content)
-			content = commpattern.sub(r'<b><a href="http://community.%s/\1/"><img src="http://stat.livejournal.com/img/community.gif" alt="[info]" width="16" height="16" style="vertical-align: bottom; border: 0;" />\1</a></b>', content)
+			content = userpattern.sub(r'<b><a href="https://\1.%s/"><img src="https://stat.livejournal.com/img/userinfo.gif" alt="[info]" width="17" height="17" style="vertical-align: bottom; border: 0;" />\1</a></b>' % gSourceAccount.site, content)
+			content = commpattern.sub(r'<b><a href="https://community.%s/\1/"><img src="https://stat.livejournal.com/img/community.gif" alt="[info]" width="16" height="16" style="vertical-align: bottom; border: 0;" />\1</a></b>', content)
 
 			result = result + '\n<br /><div id="Content">%s</div>\n' % (content, )
 
@@ -1070,7 +1070,7 @@ def synchronizeJournals(migrate = 0, retryMigrate = 0):
 						migrateThis = migrateThis and (entry['poster'] == gSourceAccount.user)
 					else:
 						# we prepend the post with a slug indicating who posted originally
-						entry['event'] = (u'<p><b>Original poster: <i><a href="http://%s.%s/">%s</a></i></b><p>' % (entry['poster'],  gSourceAccount.site, entry['poster'])) + entry['event']
+						entry['event'] = (u'<p><b>Original poster: <i><a href="https://%s.%s/">%s</a></i></b><p>' % (entry['poster'],  gSourceAccount.site, entry['poster'])) + entry['event']
 				elif considerTags and migrate:
 					# This is a personal journal, but we're migrating only specific tags.
 					# See if this entry has at least one of the target tags.
@@ -1191,7 +1191,7 @@ def generateHTML(gSourceAccount, forceIndex=0):
 def fetchNewComments(lastmaxid, lastsync, refreshall=0):
 	# TODO
 	# reimplement entirely using the undocumented XMLRPC api extensions here
-	# http://lj-dev.livejournal.com/838857.html
+	# https://lj-dev.livejournal.com/838857.html
 
 	global gAllEntries
 	try:


### PR DESCRIPTION
As explained here: https://dw-dev.dreamwidth.org/221167.html

Dreamwidth has stopped supporting the challenge-response auth mechanism because this requires storing plain-text passwords on the server.

Instead dreamwidth now expects the usage of plain-text passwords, relying on the TLS connection to the server to protect these.

Change ljmigrate to use plain-text password when connecting to dreamwidth so that it can work with dreamwidth again.

This is loosely based on a similar pull-req for ljdump: https://github.com/ghewgill/ljdump/pull/8